### PR TITLE
Add configuration file for gommitizen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-./bin/gomitizen
+/bin/gommitizen

--- a/.gommitizen.yml
+++ b/.gommitizen.yml
@@ -1,0 +1,12 @@
+types:
+    - feat
+    - fix
+    - chore
+    - docs
+    - refactor
+    - ci
+scopes:
+    - 
+    - cli
+    - cmd
+    - parser

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@ run:
 	go run main.go
 
 build:
-	go build -o ./bin/gomitizen main.go 
+	go build -o ./bin/gommitizen main.go

--- a/README.md
+++ b/README.md
@@ -2,6 +2,25 @@
 
 A simple cross platform git commit CLI. Inspired from [commitizen](https://github.com/commitizen/cz-cli).
 
+This tool aims to quickly creates commits that follow the [conventional commits](https://www.conventionalcommits.org) spec. It currently supports just a simple part of the spec: generating commit messages of the form:
+
+`<type>([optional scope])[optional !]: <commit message>`
+
+Where,
+
+- `type`: one element from `feat`, `fix`, `build`, `chore`, `ci`, `docs`, `style`, `refactor`, `perf`, `test`.
+- `scope`: indicates where the modification took place (component affected for example). Totally optional. Can be `client`, `server`, etc.
+- `!`: indicates wether the commit introduces a breaking change (if present) or not. It's optional.
+- `commit message`: a single line of max 72 chars indicate the nature of the change.
+
+Examples:
+
+```
+feat(client): add login page
+feat(client)!: migrate all webservices to v2 api
+ci: add an e2e tests step
+```
+
 # Quickstart
 
 ```bash
@@ -11,6 +30,32 @@ make build
 # run
 make run
 ```
+
+# Configuration file
+
+You can set up your custom commit scopes and types in a configuration file at the route of your repository. Create a `.gommitizen.yml` file matching the following structure:
+
+```yaml
+types:
+    - first
+    - second
+    - ...
+scopes:
+    - first-scope
+    - second-scope
+    - ...
+```
+
+If you want to propose users to use an empty scope, you can add an empty option:
+
+```yaml
+scopes:
+    - 
+    - first
+    - second
+```
+
+This file can be present, present partially, or absent. If the file or one of its option is missing, the default parameters will apply. This repository contains a `.gommitizen.yml` example file.
 
 # Licence
 

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/manifoldco/promptui v0.8.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/epsxy/gomitizen
+module github.com/epsxy/gommitizen
 
 go 1.15
 

--- a/go.sum
+++ b/go.sum
@@ -42,4 +42,7 @@ golang.org/x/tools v0.0.0-20201002184944-ecd9fd270d5d/go.mod h1:z6u4i615ZeAfBE4X
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/epsxy/gomitizen/pkg/cli"
-	"github.com/epsxy/gomitizen/pkg/cmd"
+	"github.com/epsxy/gommitizen/pkg/cli"
+	"github.com/epsxy/gommitizen/pkg/cmd"
 )
 
 func main() {

--- a/pkg/cli/git_prompt.go
+++ b/pkg/cli/git_prompt.go
@@ -12,5 +12,9 @@ func GitPrompt() string {
 	b := breakingChange()
 	m := commitShortMsg()
 
+	if s == "" {
+		return fmt.Sprintf("%s%s: %s", t, b, m)
+	}
+
 	return fmt.Sprintf("%s(%s)%s: %s", t, s, b, m)
 }

--- a/pkg/cli/git_prompt.go
+++ b/pkg/cli/git_prompt.go
@@ -2,13 +2,22 @@ package cli
 
 import (
 	"fmt"
+
+	"github.com/epsxy/gommitizen/pkg/parser"
 )
+
+type commitsConf struct {
+	Types  []string `yaml:"types,flow"`
+	Scopes []string `yaml:"scopes,flow"`
+}
 
 // GitPrompt : Global entrypoint
 func GitPrompt() string {
 
-	t := commitType()
-	s := commitScope()
+	conf := parser.EnvFileParser()
+
+	t := commitType(conf.Types)
+	s := commitScope(conf.Scopes)
 	b := breakingChange()
 	m := commitShortMsg()
 

--- a/pkg/cli/message.go
+++ b/pkg/cli/message.go
@@ -8,7 +8,7 @@ import (
 )
 
 func validateMsgLength(input string) error {
-	if len(input) > 90 {
+	if len(input) > 72 {
 		return errors.New("String length should not be > 90")
 	}
 	return nil

--- a/pkg/cli/scope.go
+++ b/pkg/cli/scope.go
@@ -6,15 +6,27 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-func commitScope() string {
+func commitScope(conf []string) string {
 	label := "Commit scope"
+
+	if conf != nil {
+		prompt := promptui.Select{
+			Label: label,
+			Items: conf,
+		}
+		_, res, err := prompt.Run()
+
+		if err != nil {
+			log.Fatal("Aborted")
+		}
+		return res
+	}
 
 	prompt := promptui.Prompt{
 		Label: label,
 	}
 
 	res, err := prompt.Run()
-
 	if err != nil {
 		log.Fatal("Aborted")
 	}

--- a/pkg/cli/type.go
+++ b/pkg/cli/type.go
@@ -6,15 +6,28 @@ import (
 	"github.com/manifoldco/promptui"
 )
 
-func commitType() string {
+func commitType(conf []string) string {
 	label := "Commit type"
-	types := []string{"feat", "fix", "build", "chore", "ci", "docs", "style", "refactor", "perf", "test"}
+
+	if conf == nil {
+		conf = []string{
+			"feat",
+			"fix",
+			"build",
+			"chore",
+			"ci",
+			"docs",
+			"style",
+			"refactor",
+			"perf",
+			"test",
+		}
+	}
 
 	prompt := promptui.Select{
 		Label: label,
-		Items: types,
+		Items: conf,
 	}
-
 	_, res, err := prompt.Run()
 
 	if err != nil {

--- a/pkg/parser/env.go
+++ b/pkg/parser/env.go
@@ -1,0 +1,46 @@
+package parser
+
+import (
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+//GommitizenConf : .yaml configuration file struct
+type GommitizenConf struct {
+	Types  []string `yaml:"types,flow"`
+	Scopes []string `yaml:"scopes,flow"`
+}
+
+func parseEnvFilePath() string {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	out, err := cmd.Output()
+
+	if err != nil {
+		log.Fatal("Unable to retrieve repository path.\nAre you in a git repository?\nAborting...")
+	}
+	return strings.Replace(string(out), "\n", "", 1)
+}
+
+//EnvFileParser : parse gommitizen env file
+func EnvFileParser() GommitizenConf {
+	var conf GommitizenConf
+	path := parseEnvFilePath()
+	s := filepath.Join(path, ".gommitizen.yml")
+
+	yamlFile, err := ioutil.ReadFile(s)
+	if err != nil {
+		return GommitizenConf{Scopes: nil, Types: nil}
+	}
+
+	err = yaml.Unmarshal(yamlFile, &conf)
+	if err != nil {
+		log.Printf("Malformed gommitizen configuration file: %v", err)
+		return GommitizenConf{Scopes: nil, Types: nil}
+	}
+	return conf
+}


### PR DESCRIPTION
# Description

Add the possibility to configure gommitizen using a .gommitizen.yml file at the root of the git repository. This file allow the user to set up custom options for defining commit types and scope for now. We will add the possibility to configure other options later.