### PR TITLE
fix: silent promptui terminal bell for all prompts

### DIFF
--- a/pkg/cli/add_all.go
+++ b/pkg/cli/add_all.go
@@ -12,8 +12,9 @@ func stageAll() {
 	types := []string{"Yes", "No"}
 
 	prompt := promptui.Select{
-		Label: label,
-		Items: types,
+		Label:  label,
+		Items:  types,
+		Stdout: &BellSkipper{},
 	}
 
 	_, res, err := prompt.Run()

--- a/pkg/cli/bell_skipper.go
+++ b/pkg/cli/bell_skipper.go
@@ -1,0 +1,27 @@
+package cli
+
+import "os"
+
+// BellSkipper implements an io.WriteCloser that skips the terminal bell
+// character (ASCII code 7), and writes the rest to os.Stderr. It is used to
+// replace readline.Stdout, that is the package used by promptui to display the
+// prompts.
+//
+// This is a workaround for the bell issue documented in
+// https://github.com/manifoldco/promptui/issues/49.
+type BellSkipper struct{}
+
+// Write implements an io.WriterCloser over os.Stderr, but it skips the terminal
+// bell character.
+func (bs *BellSkipper) Write(b []byte) (int, error) {
+	const charBell = 7 // c.f. readline.CharBell
+	if len(b) == 1 && b[0] == charBell {
+		return 0, nil
+	}
+	return os.Stderr.Write(b)
+}
+
+// Close implements an io.WriterCloser over os.Stderr.
+func (bs *BellSkipper) Close() error {
+	return os.Stderr.Close()
+}

--- a/pkg/cli/breaking_change.go
+++ b/pkg/cli/breaking_change.go
@@ -11,8 +11,9 @@ func breakingChange() string {
 	types := []string{"No", "Yes"}
 
 	prompt := promptui.Select{
-		Label: label,
-		Items: types,
+		Label:  label,
+		Items:  types,
+		Stdout: &BellSkipper{},
 	}
 
 	_, res, err := prompt.Run()

--- a/pkg/cli/message.go
+++ b/pkg/cli/message.go
@@ -20,6 +20,7 @@ func commitShortMsg() string {
 	prompt := promptui.Prompt{
 		Label:    label,
 		Validate: validateMsgLength,
+		Stdout:   &BellSkipper{},
 	}
 
 	res, err := prompt.Run()

--- a/pkg/cli/scope.go
+++ b/pkg/cli/scope.go
@@ -11,8 +11,9 @@ func commitScope(conf []string) string {
 
 	if conf != nil {
 		prompt := promptui.Select{
-			Label: label,
-			Items: conf,
+			Label:  label,
+			Items:  conf,
+			Stdout: &BellSkipper{},
 		}
 		_, res, err := prompt.Run()
 
@@ -23,7 +24,8 @@ func commitScope(conf []string) string {
 	}
 
 	prompt := promptui.Prompt{
-		Label: label,
+		Label:  label,
+		Stdout: &BellSkipper{},
 	}
 
 	res, err := prompt.Run()

--- a/pkg/cli/type.go
+++ b/pkg/cli/type.go
@@ -25,8 +25,9 @@ func commitType(conf []string) string {
 	}
 
 	prompt := promptui.Select{
-		Label: label,
-		Items: conf,
+		Label:  label,
+		Items:  conf,
+		Stdout: &BellSkipper{},
 	}
 	_, res, err := prompt.Run()
 


### PR DESCRIPTION
# Description

So there is an open issue in PromptUI repository: https://github.com/manifoldco/promptui/issues/49. On OSX, the terminal ring a bell each time a key is pressed in several configurations:
- When backspace is pressed in inputs fields
- When arrows are pressed in select fields

# Fix

This quickfix was proposed in the comments, which makes the job. It silences the terminal ring bell which was spamming at each key.